### PR TITLE
Added result mediator topics and handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
 npm-debug.log
-.idea
+.idea/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,21 +1,23 @@
 module.exports = function(grunt) {
   'use strict';
+  require('load-grunt-tasks')(grunt);
+
   grunt.initConfig({
     eslint: {
       src: ["lib/**/*.js"]
     },
     mochaTest: {
       test: {
+        src: ['lib/**/*-spec.js'],
         options: {
+          reporter: 'Spec',
+          logErrors: true,
+          timeout: 10000,
           run: true
-        },
-        src: ['lib/**/*-spec.js']
+        }
       }
     }
   });
-  grunt.loadNpmTasks("grunt-eslint");
-  grunt.loadNpmTasks('grunt-mocha-test');
-  grunt.registerTask('mocha', ['mochaTest']);
-  grunt.registerTask('unit',['eslint', 'mocha']);
-  grunt.registerTask('default', ['unit']);
+  grunt.registerTask('test', ['eslint', 'mochaTest']);
+  grunt.registerTask('default', ['test']);
 };

--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
 # FeedHenry WFM Result
 
-A result module for WFM, for working with the results of pushing a workorder through a workflow.
+A result module for WFM, for working with the results of pushing a workorder through a result.
 
 This module provides :
 - An AngularJS Service
 - An Backend Service to intialize the synchronization
 
 
-# Client-side usage
+## Client-side usage
 
-### Client-side usage (via broswerify)
 
 #### Setup
 This module is packaged in a CommonJS format, exporting the name of the Angular namespace.  The module can be included in an angular.js as follows:
@@ -40,9 +39,152 @@ These resultSync API methods all return Promises:
 | resultSync method | Description |
 | -------------------- | ----------- |
 | `resultSync.manager.list` | list all results |
-| `resultSync.manager.create(workflow)` | create a result |
-| `resultSync.manager.read(workflowId)` | read a result |
-| `resultSync.manager.update(workflow)` | update a result |
+| `resultSync.manager.create(result)` | create a result |
+| `resultSync.manager.read(resultId)` | read a result |
+| `resultSync.manager.update(result)` | update a result |
+
+### Topic Subscriptions
+
+#### wfm:result:create
+
+##### Description
+
+Creating a new Result
+
+##### Example
+
+
+```javascript
+var parameters = {
+  resultToCreate: {
+    //A Valid JSON Object
+  },
+  //Optional topic unique identifier.
+  topicUid: "uniquetopicid"
+}
+
+mediator.publish("wfm:result:create", parameters);
+```
+
+#### wfm:result:read
+
+##### Description
+
+Read a single Result
+
+##### Example
+
+
+```javascript
+var parameters = {
+  id: "resultId",
+  //Optional topic unique identifier.
+  topicUid: "uniquetopicid"
+}
+
+mediator.publish("wfm:result:read", parameters);
+```
+
+#### wfm:result:update
+
+##### Description
+
+Update a single Result
+
+##### Example
+
+
+```javascript
+var parameters = {
+  resultToUpdate: {
+    ...
+    id: "resultId"
+    ...
+  },
+  //Optional topic unique identifier.
+  topicUid: "uniquetopicid"
+}
+
+mediator.publish("wfm:result:update", parameters);
+```
+
+
+#### wfm:result:remove
+
+##### Description
+
+Remove a single Result
+
+##### Example
+
+
+```javascript
+var parameters = {
+  id: "resultId",
+  //Optional topic unique identifier.
+  topicUid: "uniquetopicid"
+}
+
+mediator.publish("wfm:result:remove", parameters);
+```
+
+
+#### wfm:result:list
+
+##### Description
+
+List All Results
+
+##### Example
+
+
+```javascript
+var parameters = {
+  //Optional topic unique identifier.
+  topicUid: "uniquetopicid"
+}
+
+mediator.publish("wfm:result:list", parameters);
+```
+
+
+### Published Topics
+
+The following topics are published by this module. Developers are free to implement these topics subscribers, or use a module that already has these subscribers implement (E.g. the [raincatcher-sync](https://github.com/feedhenry-raincatcher/raincatcher-sync) module).
+
+
+| Topic         | Description           |
+| ------------- |:-------------:| 
+| wfm:sync:results:create              |   Create a new item in the sync `results` collection |
+| wfm:sync:results:update              |   Update an existing item in the sync `results` collection |
+| wfm:sync:results:list              |   List all items in the sync `results` collection |
+| wfm:sync:results:remove              |   Remove an existing item from the sync `results` collection |
+| wfm:sync:results:read              |   Read a single item from the sync `results` collection |
+| wfm:sync:results:start              |   Start the sync process for sync `results` collection |
+| wfm:sync:results:stop              |   Stop the sync process for sync `results` collection |
+| wfm:sync:results:force_sync        |   Force a sync cycle from client to cloud for sync `results` collection |
+
+
+### Topic Subscriptions
+
+| Topic         | Description           |
+| ------------- |:-------------:| 
+| done:wfm:sync:results:create        |   A result was created in the `results` dataset |
+| error:wfm:sync:results:create        |   An error occurred when creating an item in the `results` dataset. |
+| done:wfm:sync:results:update        |   A result was updated in the `results` dataset |
+| error:wfm:sync:results:update        |   An error occurred when updating an item in the `results` dataset. |
+| done:wfm:sync:results:list        |   A list of the items in the `results` dataset completed |
+| error:wfm:sync:results:list        |   An error occurred when listing items in the `results` dataset. |
+| done:wfm:sync:results:remove        |   A result was removed from the `results` dataset |
+| error:wfm:sync:results:remove        |   An error occurred when removing an item in the `results` dataset. |
+| done:wfm:sync:results:read        |   A item was read correctly from the `results` dataset |
+| error:wfm:sync:results:read        |   An error occurred when reading an item in the `results` dataset. |
+| done:wfm:sync:results:start        |   The sync process started for the `results` dataset. |
+| error:wfm:sync:results:start        |   An error occurred when starting the `results` dataset. |
+| done:wfm:sync:results:stop        |   The sync process stopped for the `results` dataset. |
+| error:wfm:sync:results:stop        |   An error occurred when stopping the `results` dataset sync process. |
+| done:wfm:sync:results:force_sync        |  A force sync process completed for the `results` dataset. |
+| error:wfm:sync:results:force_sync        |   An error occurred when forcing the sync process for the `results` dataset. |
 
 ### Mediator events
 the module broadcasts, and listens for the following events
@@ -66,7 +208,7 @@ var express = require('express')
 // configure the express app
 ...
 
-// setup the wfm workflow sync server
+// setup the wfm result sync server
 require('fh-wfm-result/lib/server')(mediator, app, mbaasApi);
 
 ```

--- a/lib/angular/service.js
+++ b/lib/angular/service.js
@@ -4,7 +4,11 @@ var config = require('../config')
   , _ = require('lodash')
   ;
 
+var resultClient = require('../client/result-client');
+var resultMediatorSubscribers = require('../client/mediator-subscribers');
+
 module.exports = 'wfm.result.sync';
+
 
 function wrapManager($q, $timeout, manager) {
   var wrappedManager = _.create(manager);
@@ -42,26 +46,24 @@ function wrapManager($q, $timeout, manager) {
   return wrappedManager;
 }
 
-angular.module('wfm.result.sync', [require('fh-wfm-sync')])
-.factory('resultSync', function($q, $timeout, syncService) {
-  syncService.init($fh, config.syncOptions);
+angular.module('wfm.result.sync', [])
+.factory('resultSync', function($q, $timeout, mediator) {
   var resultSync = {};
   resultSync.createManager = function(queryParams) {
     if (resultSync.manager) {
       return $q.when(resultSync.manager);
     } else {
-      return resultSync.managerPromise = syncService.manage(config.datasetId, null, queryParams)
-        .then(function(manager) {
-          resultSync.manager = wrapManager($q, $timeout, manager);
-          console.log('Sync is managing dataset:', config.datasetId, 'with filter: ', queryParams);
-          return resultSync.manager;
-        });
+      resultSync.manager = wrapManager($q, $timeout, resultClient(mediator));
+      resultMediatorSubscribers.init(mediator);
+      console.log('Sync is managing dataset:', config.datasetId, 'with filter: ', queryParams);
+      return resultSync.manager;
     }
   };
   resultSync.removeManager = function() {
     if (resultSync.manager) {
       return resultSync.manager.safeStop()
         .then(function() {
+          resultMediatorSubscribers.tearDown();
           delete resultSync.manager;
         });
     }
@@ -92,5 +94,4 @@ angular.module('wfm.result.sync', [require('fh-wfm-sync')])
       mediator.publish('wfm:result:remote-update:' + result.workorderId, result);
     });
   });
-})
-;
+});

--- a/lib/client/mediator-subscribers/create-spec.js
+++ b/lib/client/mediator-subscribers/create-spec.js
@@ -1,0 +1,96 @@
+var mediator = require("fh-wfm-mediator/lib/mediator");
+var chai = require('chai');
+var _ = require('lodash');
+var CONSTANTS = require('../../constants');
+
+var expect = chai.expect;
+
+var MediatorTopicUtility = require('fh-wfm-mediator/lib/topics');
+
+describe("Result Create Mediator Topic", function() {
+
+  var mockResultToCreate = {
+    name: "This is a mock Work Order"
+  };
+
+  var expectedCreatedResult =  _.extend({_localuid: "createdResultLocalId"}, mockResultToCreate);
+
+  var topicUid = 'testtopicuid1';
+
+  var createTopic = "wfm:results:create";
+  var doneCreateTopic = "done:wfm:results:create:testtopicuid1";
+  var errorCreateTopic = "error:wfm:results:create:testtopicuid1";
+
+  var syncCreateTopic = "wfm:sync:result:create";
+  var doneSyncCreateTopic = "done:wfm:sync:result:create";
+  var errorSyncCreateTopic = "error:wfm:sync:result:create";
+
+  var resultSubscribers = new MediatorTopicUtility(mediator);
+  resultSubscribers.prefix(CONSTANTS.TOPIC_PREFIX).entity(CONSTANTS.RESULT_ENTITY_NAME);
+
+  beforeEach(function() {
+    this.subscribers = {};
+    resultSubscribers.on(CONSTANTS.TOPICS.CREATE, require('./create')(resultSubscribers));
+  });
+
+  afterEach(function() {
+    _.each(this.subscribers, function(subscriber, topic) {
+      mediator.remove(topic, subscriber.id);
+    });
+
+    resultSubscribers.unsubscribeAll();
+  });
+
+  it('should use the sync topics to create a result', function() {
+    this.subscribers[syncCreateTopic] = mediator.subscribe(syncCreateTopic, function(parameters) {
+      expect(parameters.itemToCreate).to.deep.equal(mockResultToCreate);
+      expect(parameters.topicUid).to.be.a('string');
+
+      mediator.publish(doneSyncCreateTopic + ":" + parameters.topicUid, expectedCreatedResult);
+    });
+
+    var donePromise = mediator.promise(doneCreateTopic);
+
+    mediator.publish(createTopic, {
+      resultToCreate: mockResultToCreate,
+      topicUid: topicUid
+    });
+
+    return donePromise.then(function(createdResult) {
+      expect(createdResult).to.deep.equal(expectedCreatedResult);
+    });
+  });
+
+  it('should publish an error if there is no object to update', function() {
+    var errorPromise = mediator.promise(errorCreateTopic);
+
+    mediator.publish(createTopic, {
+      topicUid: topicUid
+    });
+
+    return errorPromise.then(function(error) {
+      expect(error.message).to.have.string("Invalid Data");
+    });
+  });
+
+  it('should handle an error from the sync create topic', function() {
+    var expectedError = new Error("Error performing sync operation");
+    this.subscribers[syncCreateTopic] = mediator.subscribe(syncCreateTopic, function(parameters) {
+      expect(parameters.itemToCreate).to.deep.equal(mockResultToCreate);
+      expect(parameters.topicUid).to.be.a('string');
+
+      mediator.publish(errorSyncCreateTopic + ":" + parameters.topicUid, expectedError);
+    });
+
+    var errorPromise = mediator.promise(errorCreateTopic);
+
+    mediator.publish(createTopic, {
+      resultToCreate: mockResultToCreate,
+      topicUid: topicUid
+    });
+
+    return errorPromise.then(function(error) {
+      expect(error).to.deep.equal(expectedError);
+    });
+  });
+});

--- a/lib/client/mediator-subscribers/create.js
+++ b/lib/client/mediator-subscribers/create.js
@@ -1,0 +1,42 @@
+var _ = require('lodash');
+var CONSTANTS = require('../../constants');
+var resultClient = require('../result-client');
+
+
+/**
+ * Initialising a subscriber for creating a result.
+ *
+ * @param {object} resultEntityTopics
+ *
+ */
+module.exports = function createResultSubscriber(resultEntityTopics) {
+
+  /**
+   *
+   * Handling the creation of a result
+   *
+   * @param {object} parameters
+   * @param {object} parameters.resultToCreate   - The result item to create
+   * @param {string/number} parameters.topicUid     - (Optional)  A unique ID to be used to publish completion / error topics.
+   * @returns {*}
+   */
+  return function handleCreateResultTopic(parameters) {
+    var self = this;
+    parameters = parameters || {};
+    var resultCreateErrorTopic = resultEntityTopics.getTopic(CONSTANTS.TOPICS.CREATE, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
+
+    var resultToCreate = parameters.resultToCreate;
+
+    //If no result is passed, can't create one
+    if (!_.isPlainObject(resultToCreate)) {
+      return self.mediator.publish(resultCreateErrorTopic, new Error("Invalid Data To Create A Result."));
+    }
+
+    resultClient(self.mediator).manager.create(resultToCreate)
+    .then(function(createdResult) {
+      self.mediator.publish(resultEntityTopics.getTopic(CONSTANTS.TOPICS.CREATE, CONSTANTS.DONE_PREFIX, parameters.topicUid), createdResult);
+    }).catch(function(error) {
+      self.mediator.publish(resultCreateErrorTopic, error);
+    });
+  };
+};

--- a/lib/client/mediator-subscribers/index.js
+++ b/lib/client/mediator-subscribers/index.js
@@ -1,0 +1,45 @@
+var _ = require('lodash');
+var topicHandlers = {
+  create: require('./create'),
+  update: require('./update'),
+  remove: require('./remove'),
+  list: require('./list'),
+  read: require('./read')
+};
+var CONSTANTS = require('../../constants');
+
+var MediatorTopicUtility = require('fh-wfm-mediator/lib/topics');
+
+var resultSubscribers;
+
+module.exports = {
+  /**
+   * Initialisation of all the topics that this module is interested in.
+   * @param mediator
+   * @returns {Topics|exports|module.exports|*}
+   */
+  init: function(mediator) {
+
+    //If there is already a set of subscribers set up, then don't subscribe again.
+    if (resultSubscribers) {
+      return resultSubscribers;
+    }
+
+    resultSubscribers = new MediatorTopicUtility(mediator);
+    resultSubscribers.prefix(CONSTANTS.TOPIC_PREFIX).entity(CONSTANTS.RESULT_ENTITY_NAME);
+
+    //Setting up subscribers to the result topics.
+    _.each(CONSTANTS.TOPICS, function(topicName) {
+      if (topicHandlers[topicName]) {
+        resultSubscribers.on(topicName, topicHandlers[topicName](resultSubscribers));
+      }
+    });
+
+    return resultSubscribers;
+  },
+  tearDown: function() {
+    if (resultSubscribers) {
+      resultSubscribers.unsubscribeAll();
+    }
+  }
+};

--- a/lib/client/mediator-subscribers/list-spec.js
+++ b/lib/client/mediator-subscribers/list-spec.js
@@ -1,0 +1,70 @@
+var mediator = require("fh-wfm-mediator/lib/mediator");
+var chai = require('chai');
+var _ = require('lodash');
+var CONSTANTS = require('../../constants');
+var expect = chai.expect;
+
+var MediatorTopicUtility = require('fh-wfm-mediator/lib/topics');
+
+describe("Result List Mediator Topic", function() {
+
+  var mockResult = {
+    id: "resultid",
+    name: "This is a mock Work Order"
+  };
+
+  var results = [_.clone(mockResult), _.clone(mockResult)];
+
+  var listTopic = "wfm:results:list";
+  var doneListTopic = "done:wfm:results:list";
+  var errorListTopic = "error:wfm:results:list";
+
+  var syncListTopic = "wfm:sync:result:list";
+  var doneSyncListTopic = "done:wfm:sync:result:list";
+  var errorSyncListTopic = "error:wfm:sync:result:list";
+
+  var resultSubscribers = new MediatorTopicUtility(mediator);
+  resultSubscribers.prefix(CONSTANTS.TOPIC_PREFIX).entity(CONSTANTS.RESULT_ENTITY_NAME);
+
+  beforeEach(function() {
+    this.subscribers = {};
+    resultSubscribers.on(CONSTANTS.TOPICS.LIST, require('./list')(resultSubscribers));
+  });
+
+  afterEach(function() {
+    _.each(this.subscribers, function(subscriber, topic) {
+      mediator.remove(topic, subscriber.id);
+    });
+
+    resultSubscribers.unsubscribeAll();
+  });
+
+  it('should use the sync topics to list results', function() {
+    this.subscribers[syncListTopic] = mediator.subscribe(syncListTopic, function() {
+      mediator.publish(doneSyncListTopic, results);
+    });
+
+    var donePromise = mediator.promise(doneListTopic);
+
+    mediator.publish(listTopic);
+
+    return donePromise.then(function(arrayOfResults) {
+      expect(arrayOfResults).to.deep.equal(results);
+    });
+  });
+
+  it('should handle an error from the sync create topic', function() {
+    var expectedError = new Error("Error performing sync operation");
+    this.subscribers[syncListTopic] = mediator.subscribe(syncListTopic, function() {
+      mediator.publish(errorSyncListTopic, expectedError);
+    });
+
+    var errorPromise = mediator.promise(errorListTopic);
+
+    mediator.publish(listTopic);
+
+    return errorPromise.then(function(error) {
+      expect(error).to.deep.equal(expectedError);
+    });
+  });
+});

--- a/lib/client/mediator-subscribers/list.js
+++ b/lib/client/mediator-subscribers/list.js
@@ -1,0 +1,34 @@
+var CONSTANTS = require('../../constants');
+var resultClient = require('../result-client');
+
+/**
+ * Initialsing a subscriber for Listing results.
+ *
+ * @param {object} resultEntityTopics
+ *
+ */
+module.exports = function listResultSubscriber(resultEntityTopics) {
+
+  /**
+   *
+   * Handling the listing of results
+   *
+   * @param {object} parameters
+   * @param {string/number} parameters.topicUid  - (Optional)  A unique ID to be used to publish completion / error topics.
+   * @returns {*}
+   */
+  return function handleListResultsTopic(parameters) {
+    var self = this;
+    parameters = parameters || {};
+    var resultListErrorTopic = resultEntityTopics.getTopic(CONSTANTS.TOPICS.LIST, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
+
+    var resultListDoneTopic = resultEntityTopics.getTopic(CONSTANTS.TOPICS.LIST, CONSTANTS.DONE_PREFIX, parameters.topicUid);
+
+    resultClient(self.mediator).manager.list()
+    .then(function(arrayOfResults) {
+      self.mediator.publish(resultListDoneTopic, arrayOfResults);
+    }).catch(function(error) {
+      self.mediator.publish(resultListErrorTopic, error);
+    });
+  };
+};

--- a/lib/client/mediator-subscribers/read-spec.js
+++ b/lib/client/mediator-subscribers/read-spec.js
@@ -1,0 +1,86 @@
+var mediator = require("fh-wfm-mediator/lib/mediator");
+var chai = require('chai');
+var _ = require('lodash');
+var CONSTANTS = require('../../constants');
+var expect = chai.expect;
+
+var MediatorTopicUtility = require('fh-wfm-mediator/lib/topics');
+
+describe("Result Read Mediator Topic", function() {
+
+  var mockResult = {
+    id: "resultid",
+    name: "This is a mock Work Order"
+  };
+
+  var readTopic = "wfm:results:read";
+  var doneReadTopic = "done:wfm:results:read:resultid";
+  var errorReadTopic = "error:wfm:results:read";
+
+  var syncReadTopic = "wfm:sync:result:read";
+  var doneSyncReadTopic = "done:wfm:sync:result:read:resultid";
+  var errorSyncReadTopic = "error:wfm:sync:result:read:resultid";
+
+  var resultSubscribers = new MediatorTopicUtility(mediator);
+  resultSubscribers.prefix(CONSTANTS.TOPIC_PREFIX).entity(CONSTANTS.RESULT_ENTITY_NAME);
+
+  var readSubscribers = require('./read')(resultSubscribers);
+
+  beforeEach(function() {
+    this.subscribers = {};
+    resultSubscribers.on(CONSTANTS.TOPICS.READ, readSubscribers);
+  });
+
+  afterEach(function() {
+    _.each(this.subscribers, function(subscriber, topic) {
+      mediator.remove(topic, subscriber.id);
+    });
+
+    resultSubscribers.unsubscribeAll();
+  });
+
+  it('should use the sync topics to read result', function() {
+    this.subscribers[syncReadTopic] = mediator.subscribe(syncReadTopic, function(parameters) {
+      expect(parameters.id).to.be.a('string');
+      expect(parameters.topicUid).to.equal(mockResult.id);
+
+      mediator.publish(doneSyncReadTopic, mockResult);
+    });
+
+    var donePromise = mediator.promise(doneReadTopic);
+
+    mediator.publish(readTopic, {id: mockResult.id, topicUid: mockResult.id});
+
+    return donePromise.then(function(readResult) {
+      expect(readResult).to.deep.equal(mockResult);
+    });
+  });
+
+  it('should publish an error if there is no ID to read', function() {
+    var errorPromise = mediator.promise(errorReadTopic);
+
+    mediator.publish(readTopic);
+
+    return errorPromise.then(function(error) {
+      expect(error.message).to.have.string("Expected An ID");
+    });
+  });
+
+  it('should handle an error from the sync create topic', function() {
+    var expectedError = new Error("Error performing sync operation");
+    this.subscribers[syncReadTopic] = mediator.subscribe(syncReadTopic, function(parameters) {
+      expect(parameters.id).to.be.a('string');
+      expect(parameters.topicUid).to.equal(mockResult.id);
+
+      mediator.publish(errorSyncReadTopic, expectedError);
+    });
+
+    var errorPromise = mediator.promise(errorReadTopic + ":" + mockResult.id);
+
+    mediator.publish(readTopic, {id: mockResult.id, topicUid: mockResult.id});
+
+    return errorPromise.then(function(error) {
+      expect(error).to.deep.equal(expectedError);
+    });
+  });
+});

--- a/lib/client/mediator-subscribers/read.js
+++ b/lib/client/mediator-subscribers/read.js
@@ -1,0 +1,43 @@
+var CONSTANTS = require('../../constants');
+var resultClient = require('../result-client');
+
+/**
+ * Initialsing a subscriber for reading results.
+ *
+ * @param {object} resultEntityTopics
+ *
+ */
+module.exports = function readResultSubscriber(resultEntityTopics) {
+
+
+  /**
+   *
+   * Handling the reading of a single result
+   *
+   * @param {object} parameters
+   * @param {string} parameters.id - The ID of the result to read.
+   * @param {string/number} parameters.topicUid     - (Optional)  A unique ID to be used to publish completion / error topics.
+   * @returns {*}
+   */
+  return function handleReadResultsTopic(parameters) {
+    var self = this;
+    parameters = parameters || {};
+
+    var resultReadErrorTopic = resultEntityTopics.getTopic(CONSTANTS.TOPICS.READ, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
+
+    var resultReadDoneTopic = resultEntityTopics.getTopic(CONSTANTS.TOPICS.READ, CONSTANTS.DONE_PREFIX, parameters.topicUid);
+
+    //If there is no ID, then we can't read the result.
+    if (!parameters.id) {
+      return self.mediator.publish(resultReadErrorTopic, new Error("Expected An ID When Reading A Result"));
+    }
+
+    resultClient(self.mediator).manager.read(parameters.id)
+    .then(function(result) {
+      self.mediator.publish(resultReadDoneTopic, result);
+    }).catch(function(error) {
+      self.mediator.publish(resultReadErrorTopic, error);
+    });
+  };
+
+};

--- a/lib/client/mediator-subscribers/remove-spec.js
+++ b/lib/client/mediator-subscribers/remove-spec.js
@@ -1,0 +1,82 @@
+var mediator = require("fh-wfm-mediator/lib/mediator");
+var chai = require('chai');
+var _ = require('lodash');
+var CONSTANTS = require('../../constants');
+var expect = chai.expect;
+
+var MediatorTopicUtility = require('fh-wfm-mediator/lib/topics');
+
+describe("Result Remove Mediator Topic", function() {
+
+  var mockResult = {
+    id: "resultid",
+    name: "This is a mock Work Order"
+  };
+
+  var removeTopic = "wfm:results:remove";
+  var doneRemoveTopic = "done:wfm:results:remove:resultid";
+  var errorRemoveTopic = "error:wfm:results:remove";
+
+  var syncRemoveTopic = "wfm:sync:result:remove";
+  var doneSyncRemoveTopic = "done:wfm:sync:result:remove:resultid";
+  var errorSyncRemoveTopic = "error:wfm:sync:result:remove:resultid";
+
+  var resultSubscribers = new MediatorTopicUtility(mediator);
+  resultSubscribers.prefix(CONSTANTS.TOPIC_PREFIX).entity(CONSTANTS.RESULT_ENTITY_NAME);
+
+  beforeEach(function() {
+    this.subscribers = {};
+    resultSubscribers.on(CONSTANTS.TOPICS.REMOVE, require('./remove')(resultSubscribers));
+  });
+
+  afterEach(function() {
+    _.each(this.subscribers, function(subscriber, topic) {
+      mediator.remove(topic, subscriber.id);
+    });
+
+    resultSubscribers.unsubscribeAll();
+  });
+
+  it('should use the sync topics to remove a result', function() {
+    this.subscribers[syncRemoveTopic] = mediator.subscribe(syncRemoveTopic, function(parameters) {
+      expect(parameters.id).to.be.a('string');
+      expect(parameters.topicUid).to.equal(mockResult.id);
+
+      mediator.publish(doneSyncRemoveTopic, mockResult);
+    });
+
+    var donePromise = mediator.promise(doneRemoveTopic);
+
+    mediator.publish(removeTopic, {id: mockResult.id, topicUid: mockResult.id});
+
+    return donePromise;
+  });
+
+  it('should publish an error if there is no ID to remove', function() {
+    var errorPromise = mediator.promise(errorRemoveTopic);
+
+    mediator.publish(removeTopic);
+
+    return errorPromise.then(function(error) {
+      expect(error.message).to.have.string("Expected An ID");
+    });
+  });
+
+  it('should handle an error from the sync create topic', function() {
+    var expectedError = new Error("Error performing sync operation");
+    this.subscribers[syncRemoveTopic] = mediator.subscribe(syncRemoveTopic, function(parameters) {
+      expect(parameters.id).to.be.a('string');
+      expect(parameters.topicUid).to.equal(mockResult.id);
+
+      mediator.publish(errorSyncRemoveTopic, expectedError);
+    });
+
+    var errorPromise = mediator.promise(errorRemoveTopic + ":" + mockResult.id);
+
+    mediator.publish(removeTopic, {id: mockResult.id, topicUid: mockResult.id});
+
+    return errorPromise.then(function(error) {
+      expect(error).to.deep.equal(expectedError);
+    });
+  });
+});

--- a/lib/client/mediator-subscribers/remove.js
+++ b/lib/client/mediator-subscribers/remove.js
@@ -1,0 +1,43 @@
+var CONSTANTS = require('../../constants');
+var resultClient = require('../result-client');
+
+/**
+ * Initialsing a subscriber for removing results.
+ *
+ * @param {object} resultEntityTopics
+ *
+ */
+module.exports = function removeResultSubscriber(resultEntityTopics) {
+
+
+  /**
+   *
+   * Handling the removal of a single result
+   *
+   * @param {object} parameters
+   * @param {string} parameters.id - The ID of the result to remove.
+   * @param {string/number} parameters.topicUid     - (Optional)  A unique ID to be used to publish completion / error topics.
+   * @returns {*}
+   */
+  return function handleRemoveResult(parameters) {
+    var self = this;
+    parameters = parameters || {};
+    var resultRemoveErrorTopic = resultEntityTopics.getTopic(CONSTANTS.TOPICS.REMOVE, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
+
+    var resultRemoveDoneTopic = resultEntityTopics.getTopic(CONSTANTS.TOPICS.REMOVE, CONSTANTS.DONE_PREFIX, parameters.topicUid);
+
+    //If there is no ID, then we can't read the result.
+    if (!parameters.id) {
+      return self.mediator.publish(resultRemoveErrorTopic, new Error("Expected An ID When Removing A Result"));
+    }
+
+    resultClient(self.mediator).manager.delete({
+      id: parameters.id
+    })
+    .then(function() {
+      self.mediator.publish(resultRemoveDoneTopic);
+    }).catch(function(error) {
+      self.mediator.publish(resultRemoveErrorTopic, error);
+    });
+  };
+};

--- a/lib/client/mediator-subscribers/update-spec.js
+++ b/lib/client/mediator-subscribers/update-spec.js
@@ -1,0 +1,111 @@
+var mediator = require("fh-wfm-mediator/lib/mediator");
+var chai = require('chai');
+var _ = require('lodash');
+var CONSTANTS = require('../../constants');
+var expect = chai.expect;
+
+var MediatorTopicUtility = require('fh-wfm-mediator/lib/topics');
+
+
+describe("Result Update Mediator Topic", function() {
+
+  var mockResultToUpdate = {
+    id: "resultidtoupdate",
+    name: "This is a mock Work Order"
+  };
+
+  var expectedUpdatedResult =  _.defaults({name: "Updated Result"}, mockResultToUpdate);
+
+  var topicUid = 'testtopicuid1';
+
+  var updateTopic = "wfm:results:update";
+  var doneUpdateTopic = "done:wfm:results:update:testtopicuid1";
+  var errorUpdateTopic = "error:wfm:results:update:testtopicuid1";
+
+  var syncUpdateTopic = "wfm:sync:result:update";
+  var doneSyncUpdateTopic = "done:wfm:sync:result:update";
+  var errorSyncUpdateTopic = "error:wfm:sync:result:update";
+
+  var resultSubscribers = new MediatorTopicUtility(mediator);
+  resultSubscribers.prefix(CONSTANTS.TOPIC_PREFIX).entity(CONSTANTS.RESULT_ENTITY_NAME);
+
+  beforeEach(function() {
+    this.subscribers = {};
+    resultSubscribers.on(CONSTANTS.TOPICS.UPDATE, require('./update')(resultSubscribers));
+  });
+
+  afterEach(function() {
+    _.each(this.subscribers, function(subscriber, topic) {
+      mediator.remove(topic, subscriber.id);
+    });
+
+    resultSubscribers.unsubscribeAll();
+  });
+
+  it('should use the sync topics to update a result', function() {
+    this.subscribers[syncUpdateTopic] = mediator.subscribe(syncUpdateTopic, function(parameters) {
+      expect(parameters.itemToUpdate).to.deep.equal(mockResultToUpdate);
+      expect(parameters.topicUid).to.be.a('string');
+
+      mediator.publish(doneSyncUpdateTopic + ":" + parameters.topicUid, expectedUpdatedResult);
+    });
+
+    var donePromise = mediator.promise(doneUpdateTopic);
+
+    mediator.publish(updateTopic, {
+      resultToUpdate: mockResultToUpdate,
+      topicUid: topicUid
+    });
+
+    return donePromise.then(function(updatedResult) {
+      expect(updatedResult).to.deep.equal(expectedUpdatedResult);
+    });
+  });
+
+  it('should publish an error if there is no object to update', function() {
+    var errorPromise = mediator.promise(errorUpdateTopic);
+
+    mediator.publish(updateTopic, {
+      topicUid: topicUid
+    });
+
+    return errorPromise.then(function(error) {
+      expect(error.message).to.have.string("Invalid Data");
+    });
+  });
+
+  it('should publish an error if there is no result id', function() {
+    var errorPromise = mediator.promise(errorUpdateTopic);
+
+    mediator.publish(updateTopic, {
+      resultToUpdate: {},
+      topicUid: topicUid
+    });
+
+    return errorPromise.then(function(error) {
+      expect(error.message).to.have.string("Invalid Data");
+    });
+  });
+
+  it('should handle an error from the sync create topic', function() {
+    var expectedError = new Error("Error performing sync operation");
+
+    this.subscribers[syncUpdateTopic] = mediator.subscribe(syncUpdateTopic, function(parameters) {
+      expect(parameters.itemToUpdate).to.deep.equal(mockResultToUpdate);
+      expect(parameters.topicUid).to.be.a('string');
+
+      mediator.publish(errorSyncUpdateTopic + ":" + parameters.topicUid, expectedError);
+    });
+
+    var errorPromise = mediator.promise(errorUpdateTopic);
+
+    mediator.publish(updateTopic, {
+      resultToUpdate: mockResultToUpdate,
+      topicUid: topicUid
+    });
+
+    return errorPromise.then(function(error) {
+      expect(error).to.deep.equal(expectedError);
+    });
+  });
+});

--- a/lib/client/mediator-subscribers/update.js
+++ b/lib/client/mediator-subscribers/update.js
@@ -1,0 +1,43 @@
+var CONSTANTS = require('../../constants');
+var _ = require('lodash');
+var resultClient = require('../result-client');
+
+/**
+ * Initialsing a subscriber for updating a result.
+ *
+ * @param {object} resultEntityTopics
+ *
+ */
+module.exports = function updateResultSubscriber(resultEntityTopics) {
+
+  /**
+   *
+   * Handling the update of a result
+   *
+   * @param {object} parameters
+   * @param {object} parameters.resultToUpdate   - The result item to update
+   * @param {string/number} parameters.topicUid     - (Optional)  A unique ID to be used to publish completion / error topics.
+   * @returns {*}
+   */
+  return function handleUpdateTopic(parameters) {
+    var self = this;
+    parameters = parameters || {};
+    var resultUpdateErrorTopic = resultEntityTopics.getTopic(CONSTANTS.TOPICS.UPDATE, CONSTANTS.ERROR_PREFIX, parameters.topicUid);
+
+    var resultUpdateDoneTopic = resultEntityTopics.getTopic(CONSTANTS.TOPICS.UPDATE, CONSTANTS.DONE_PREFIX, parameters.topicUid);
+
+    var resultToUpdate = parameters.resultToUpdate;
+
+    //If no result is passed, can't update one. Also require the ID of the workorde to update it.
+    if (!_.isPlainObject(resultToUpdate) || !resultToUpdate.id) {
+      return self.mediator.publish(resultUpdateErrorTopic, new Error("Invalid Data To Update A Result."));
+    }
+
+    resultClient(self.mediator).manager.update(resultToUpdate)
+    .then(function(updatedResult) {
+      self.mediator.publish(resultUpdateDoneTopic, updatedResult);
+    }).catch(function(error) {
+      self.mediator.publish(resultUpdateErrorTopic, error);
+    });
+  };
+};

--- a/lib/client/result-client/index.js
+++ b/lib/client/result-client/index.js
@@ -1,0 +1,224 @@
+var q = require('q');
+var _ = require('lodash');
+var shortid = require('shortid');
+var CONSTANTS = require('../../constants');
+var config = require('../../config');
+var MediatorTopicUtility = require('fh-wfm-mediator/lib/topics');
+var mediator, manager, resultSyncSubscribers;
+
+/**
+ *
+ * Getting Promises for done and error topics.
+ *
+ * @param doneTopicPromise  - A promise for the done topic.
+ * @param errorTopicPromise - A promise for the error topic.
+ * @returns {*}
+ */
+function getTopicPromises(doneTopicPromise, errorTopicPromise) {
+  var deferred = q.defer();
+
+  doneTopicPromise.then(function(createdResult) {
+    deferred.resolve(createdResult);
+  });
+
+  errorTopicPromise.then(function(error) {
+    deferred.reject(error);
+  });
+
+  return deferred.promise;
+}
+
+
+/**
+ *
+ * Creating a new result.
+ *
+ * @param {object} resultToCreate - The Result to create.
+ */
+function create(resultToCreate) {
+
+  //Creating a unique channel to get the response
+  var topicUid = shortid.generate();
+
+  var topicParams = {topicUid: topicUid, itemToCreate: resultToCreate};
+
+  var donePromise = mediator.promise(resultSyncSubscribers.getTopic(CONSTANTS.TOPICS.CREATE, CONSTANTS.DONE_PREFIX, topicUid));
+
+  var errorPromise = mediator.promise(resultSyncSubscribers.getTopic(CONSTANTS.TOPICS.CREATE, CONSTANTS.ERROR_PREFIX, topicUid));
+
+  mediator.publish(resultSyncSubscribers.getTopic(CONSTANTS.TOPICS.CREATE), topicParams);
+
+  return getTopicPromises(donePromise, errorPromise);
+}
+
+/**
+ *
+ * Updating an existing result.
+ *
+ * @param {object} resultToUpdate - The result to update
+ * @param {string} resultToUpdate.id - The ID of the result to update
+ */
+function update(resultToUpdate) {
+  var topicParams = {topicUid: resultToUpdate.id, itemToUpdate: resultToUpdate};
+
+  var donePromise = mediator.promise(resultSyncSubscribers.getTopic(CONSTANTS.TOPICS.UPDATE, CONSTANTS.DONE_PREFIX, topicParams.topicUid));
+
+  var errorPromise = mediator.promise(resultSyncSubscribers.getTopic(CONSTANTS.TOPICS.UPDATE, CONSTANTS.ERROR_PREFIX, topicParams.topicUid));
+
+  mediator.publish(resultSyncSubscribers.getTopic(CONSTANTS.TOPICS.UPDATE), topicParams);
+
+  return getTopicPromises(donePromise, errorPromise);
+}
+
+/***
+ *
+ * Reading a single result.
+ *
+ * @param {string} resultId - The ID of the result to read
+ */
+function read(resultId) {
+  var donePromise = mediator.promise(resultSyncSubscribers.getTopic(CONSTANTS.TOPICS.READ, CONSTANTS.DONE_PREFIX, resultId));
+
+  var errorPromise = mediator.promise(resultSyncSubscribers.getTopic(CONSTANTS.TOPICS.READ, CONSTANTS.ERROR_PREFIX, resultId));
+
+  mediator.publish(resultSyncSubscribers.getTopic(CONSTANTS.TOPICS.READ), {id: resultId, topicUid: resultId});
+
+  return getTopicPromises(donePromise, errorPromise);
+}
+
+/**
+ * Listing All Results
+ */
+function list() {
+  var donePromise = mediator.promise(resultSyncSubscribers.getTopic(CONSTANTS.TOPICS.LIST, CONSTANTS.DONE_PREFIX));
+
+  var errorPromise = mediator.promise(resultSyncSubscribers.getTopic(CONSTANTS.TOPICS.LIST, CONSTANTS.ERROR_PREFIX));
+
+  mediator.publish(resultSyncSubscribers.getTopic(CONSTANTS.TOPICS.LIST));
+
+  return getTopicPromises(donePromise, errorPromise);
+}
+
+/**
+ *
+ * Removing a workororder using the sync topics
+ *
+ * @param {object} resultToRemove
+ * @param {string} resultToRemove.id - The ID of the workoroder to remove
+ */
+function remove(resultToRemove) {
+
+  var donePromise = mediator.promise(resultSyncSubscribers.getTopic(CONSTANTS.TOPICS.REMOVE, CONSTANTS.DONE_PREFIX, resultToRemove.id));
+
+  var errorPromise = mediator.promise(resultSyncSubscribers.getTopic(CONSTANTS.TOPICS.REMOVE, CONSTANTS.ERROR_PREFIX, resultToRemove.id));
+
+  mediator.publish(resultSyncSubscribers.getTopic(CONSTANTS.TOPICS.REMOVE),  {id: resultToRemove.id, topicUid: resultToRemove.id});
+
+  return getTopicPromises(donePromise, errorPromise);
+}
+
+/**
+ * Starting the synchronisation process for results.
+ */
+function start() {
+
+  var donePromise = mediator.promise(resultSyncSubscribers.getTopic(CONSTANTS.TOPICS.START, CONSTANTS.DONE_PREFIX));
+
+  var errorPromise = mediator.promise(resultSyncSubscribers.getTopic(CONSTANTS.TOPICS.START, CONSTANTS.ERROR_PREFIX));
+
+  mediator.publish(resultSyncSubscribers.getTopic(CONSTANTS.TOPICS.START));
+
+  return getTopicPromises(donePromise, errorPromise);
+}
+
+/**
+ * Stopping the synchronisation process for results.
+ */
+function stop() {
+  var donePromise = mediator.promise(resultSyncSubscribers.getTopic(CONSTANTS.TOPICS.STOP, CONSTANTS.DONE_PREFIX));
+
+  var errorPromise = mediator.promise(resultSyncSubscribers.getTopic(CONSTANTS.TOPICS.STOP, CONSTANTS.ERROR_PREFIX));
+
+  mediator.publish(resultSyncSubscribers.getTopic(CONSTANTS.TOPICS.STOP));
+
+  return getTopicPromises(donePromise, errorPromise);
+}
+
+/**
+ * Forcing the results to sync to the remote store.
+ */
+function forceSync() {
+  var donePromise = mediator.promise(resultSyncSubscribers.getTopic(CONSTANTS.TOPICS.FORCE_SYNC, CONSTANTS.DONE_PREFIX));
+
+  var errorPromise = mediator.promise(resultSyncSubscribers.getTopic(CONSTANTS.TOPICS.FORCE_SYNC, CONSTANTS.ERROR_PREFIX));
+
+  mediator.publish(resultSyncSubscribers.getTopic(CONSTANTS.TOPICS.FORCE_SYNC));
+
+  return getTopicPromises(donePromise, errorPromise);
+}
+
+/**
+ * Safe stop forces a synchronisation to the remote server and then stops the synchronisation process.
+ * @returns {Promise}
+ */
+function safeStop() {
+  return forceSync().then(stop);
+}
+
+
+/**
+ * Waiting for the synchronisation process to complete to the remote cluster.
+ */
+function waitForSync() {
+  return mediator.promise(resultSyncSubscribers.getTopic(CONSTANTS.TOPICS.SYNC_COMPLETE));
+}
+
+function ManagerWrapper(_manager) {
+  this.manager = _manager;
+  var self = this;
+
+  var methodNames = ['create', 'read', 'update', 'delete', 'list', 'start', 'stop', 'safeStop', 'forceSync', 'waitForSync'];
+  methodNames.forEach(function(methodName) {
+    self[methodName] = function() {
+      return q.when(self.manager[methodName].apply(self.manager, arguments));
+    };
+  });
+}
+
+
+/**
+ *
+ * Initialising the result-client with a mediator.
+ *
+ * @param _mediator
+ * @returns {ManagerWrapper|*}
+ */
+module.exports = function(_mediator) {
+
+  //If there is already a manager, use this
+  if (manager) {
+    return manager;
+  }
+
+  mediator = _mediator;
+
+  resultSyncSubscribers = new MediatorTopicUtility(mediator);
+  resultSyncSubscribers.prefix(CONSTANTS.SYNC_TOPIC_PREFIX).entity(config.datasetId);
+
+  manager = new ManagerWrapper({
+    create: create,
+    update: update,
+    list: list,
+    delete: remove,
+    start: start,
+    stop: stop,
+    read: read,
+    safeStop: safeStop,
+    forceSync: forceSync,
+    publishRecordDeltaReceived: _.noop,
+    waitForSync: waitForSync,
+    datasetId: config.datasetId
+  });
+
+  return manager;
+};

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,19 @@
+module.exports = {
+  TOPIC_PREFIX: "wfm",
+  RESULT_ENTITY_NAME: "results",
+  SYNC_TOPIC_PREFIX: "wfm:sync",
+  TOPIC_SEPARATOR: ":",
+  ERROR_PREFIX: "error",
+  DONE_PREFIX: "done",
+  TOPICS: {
+    CREATE: "create",
+    UPDATE: "update",
+    LIST: "list",
+    REMOVE: "remove",
+    READ: "read",
+    START: "start",
+    STOP: "stop",
+    FORCE_SYNC: "force_sync",
+    SYNC_COMPLETE: "sync_complete"
+  }
+};

--- a/lib/server-spec.js
+++ b/lib/server-spec.js
@@ -1,13 +1,8 @@
-var sinon = require('sinon');
-var proxyquire = require('proxyquire');
 var express = require('express');
 var chai = require('chai');
 var expect = chai.expect;
 var app = express();
 var mockMbaasApi = {};
-var mockSync = {
-  init: sinon.spy()
-};
 
 var CLOUD_TOPICS = {
   create: "wfm:cloud:result:create",
@@ -30,9 +25,7 @@ var mediator = require('fh-wfm-mediator/lib/mediator.js');
  * Set of unit tests for the sync topic subscribers
  */
 describe('Result Sync', function() {
-  var resultServer = proxyquire('./server.js', {
-    'fh-wfm-sync/lib/server': mockSync
-  });
+  var resultServer = require('./server.js');
 
   //Create
   it('should publish to done create cloud topic when the request to create a result has been completed', function() {

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,13 +1,12 @@
 'use strict';
 
-var sync = require('fh-wfm-sync/lib/server');
 var config = require('./config');
 var shortid = require('shortid');
 
 var ResultTopics = require('fh-wfm-mediator/lib/topics');
 
 
-module.exports = function(mediator, app, mbaasApi) {
+module.exports = function(mediator) {
   //Used for cloud data storage topics
   var resultCloudDataTopics = new ResultTopics(mediator);
   resultCloudDataTopics.prefix(config.cloudDataTopicPrefix).entity(config.datasetId);
@@ -15,8 +14,6 @@ module.exports = function(mediator, app, mbaasApi) {
   //Used for cloud topics
   var resultCloudTopics = new ResultTopics(mediator);
   resultCloudTopics.prefix(config.cloudTopicPrefix).entity(config.datasetId);
-
-  sync.init(mediator, mbaasApi, config.datasetId, config.syncOptions);
 
   /**
    * Subscribers to sync topics which publishes to a data storage topic, subscribed to by a storage module,
@@ -33,8 +30,9 @@ module.exports = function(mediator, app, mbaasApi) {
       });
   });
 
-  resultCloudTopics.on('list', function() {
-    return resultCloudDataTopics.request('list');
+  resultCloudTopics.on('list', function(listOptions) {
+    listOptions = listOptions || {};
+    return resultCloudDataTopics.request('list', listOptions.filter, {uid: null});
   });
 
   resultCloudTopics.on('update', function(resultToUpdate) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-result",
-  "version": "0.0.17",
+  "version": "0.1.0-alpha.1",
   "description": "A result module for WFM, for working with the results of pushing a workorder through a workflow",
   "main": "lib/angular/result-ng.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -21,23 +21,26 @@
   "dependencies": {
     "angular-messages": "1.5.3",
     "express": "4.14.0",
-    "fh-wfm-sync": "0.0.16",
-    "fh-wfm-mediator": "0.1.0",
     "lodash": "4.7.0",
     "ng-feedhenry": "0.3.0",
-    "q": "1.4.1",
-    "shortid": "^2.2.6"
+    "fh-wfm-mediator": "0.2.0-0",
+    "string-template": "^1.0.0",
+    "shortid": "^2.2.6",
+    "q": "1.4.1"
   },
   "devDependencies": {
     "body-parser": "1.15.0",
     "chai": "^3.5.0",
     "fh-wfm-template-build": "0.0.9",
-    "grunt": "^1.0.1",
-    "grunt-eslint": "^18.0.0",
-    "grunt-mocha-test": "^0.13.2",
-    "mocha": "2.4.5",
-    "proxyquire": "^1.7.10",
+    "grunt": "1.0.1",
+    "grunt-eslint": "18.0.0",
+    "grunt-mocha-test": "0.13.2",
+    "load-grunt-tasks": "3.5.2",
+    "mocha": "3.2.0",
+    "nsp": "2.6.2",
+    "request": "2.69.0",
     "should": "8.3.0",
-    "sinon": "^1.17.7"
+    "sinon": "1.17.6",
+    "sinon-as-promised": "4.0.2"
   }
 }


### PR DESCRIPTION
# Motivation

The fh-wfm-sync direct dependency has been removed from this module.

Any interaction with the fh-wfm-sync module (or any other sync module) will now be done through the mediator pattern.

# Changes

- Added new CRUDL topics for results
- Removed fh-wfm-sync from the dependencies of the module.
- Switched the client to use mediator topics instead of the syncClient from fh-wfm-sync.