### PR TITLE
Remove NSP checks from Travis

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "grunt-mocha-test": "0.13.2",
     "load-grunt-tasks": "3.5.2",
     "mocha": "3.2.0",
-    "nsp": "2.6.2",
     "request": "2.69.0",
     "should": "8.3.0",
     "sinon": "1.17.6",


### PR DESCRIPTION
- These are no longer necessary as Snyk is being used for security checks on PR's.