### PR TITLE
Not assuming that the result has a remote ID

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,7 +12,7 @@ module.exports = function(grunt) {
         options: {
           reporter: 'Spec',
           logErrors: true,
-          timeout: 10000,
+          timeout: 1000,
           run: true
         }
       }

--- a/lib/client/mediator-subscribers/update.js
+++ b/lib/client/mediator-subscribers/update.js
@@ -29,7 +29,7 @@ module.exports = function updateResultSubscriber(resultEntityTopics) {
     var resultToUpdate = parameters.resultToUpdate;
 
     //If no result is passed, can't update one. Also require the ID of the workorde to update it.
-    if (!_.isPlainObject(resultToUpdate) || !resultToUpdate.id) {
+    if (!_.isPlainObject(resultToUpdate)) {
       return self.mediator.publish(resultUpdateErrorTopic, new Error("Invalid Data To Update A Result."));
     }
 


### PR DESCRIPTION
# Motivation

This is to allow the sync framework use the `_localuid` when updating records that have not yet gotten a remote ID