### PR TITLE
Unassigning the resultSubscribers when tearing down

### DIFF
--- a/lib/client/mediator-subscribers/index.js
+++ b/lib/client/mediator-subscribers/index.js
@@ -40,6 +40,7 @@ module.exports = {
   tearDown: function() {
     if (resultSubscribers) {
       resultSubscribers.unsubscribeAll();
+      resultSubscribers = null;
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-result",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A result module for WFM, for working with the results of pushing a workorder through a workflow",
   "main": "lib/angular/result-ng.js",
   "repository": {


### PR DESCRIPTION
# Change 

Fixed a bug where the subscribers were unassigned but it was never re-created