### PR TITLE
Raincatch 786 create new hashing functions

### DIFF
--- a/lib/client/mediator-subscribers/update-spec.js
+++ b/lib/client/mediator-subscribers/update-spec.js
@@ -81,7 +81,7 @@ describe("Result Update Mediator Topic", function() {
     var errorPromise = mediator.promise(errorUpdateTopic);
 
     mediator.publish(updateTopic, {
-      resultToUpdate: {},
+      resultToUpdate: "notaresult",
       topicUid: topicUid
     });
 

--- a/lib/client/mediator-subscribers/update.js
+++ b/lib/client/mediator-subscribers/update.js
@@ -28,7 +28,7 @@ module.exports = function updateResultSubscriber(resultEntityTopics, resultClien
     var resultToUpdate = parameters.resultToUpdate;
 
     //If no result is passed, can't update one. Also require the ID of the workorde to update it.
-    if (!_.isPlainObject(resultToUpdate) || !resultToUpdate.id) {
+    if (!_.isPlainObject(resultToUpdate)) {
       return self.mediator.publish(resultUpdateErrorTopic, new Error("Invalid Data To Update A Result."));
     }
 

--- a/lib/cloud/index.js
+++ b/lib/cloud/index.js
@@ -35,7 +35,9 @@ module.exports = function(mediator) {
   });
 
   resultCloudTopics.on('update', function(resultToUpdate) {
-    return resultCloudDataTopics.request('update', resultToUpdate, {uid: resultToUpdate.id});
+
+    //The server ID is not guaranteed to have been assigned yet, so the UID could be the _localuid
+    return resultCloudDataTopics.request('update', resultToUpdate, {uid: resultToUpdate.id || resultToUpdate._localuid});
   });
 
   resultCloudTopics.on('read', function(uid) {

--- a/lib/cloud/index.js
+++ b/lib/cloud/index.js
@@ -30,8 +30,16 @@ module.exports = function(mediator) {
   });
 
   resultCloudTopics.on('list', function(listOptions) {
+    var self = this;
     listOptions = listOptions || {};
-    return resultCloudDataTopics.request('list', listOptions.filter, {uid: null});
+    listOptions.filter = listOptions.filter || {};
+    listOptions.filter.topicUid = listOptions.topicUid || shortid.generate();
+
+    resultCloudDataTopics.request('list', listOptions.filter, {uid: listOptions.filter.topicUid}).then(function(list) {
+      self.mediator.publish(resultCloudTopics.getTopic('list', 'done', listOptions.topicUid), list);
+    }).catch(function(err) {
+      self.mediator.publish(resultCloudTopics.getTopic('list', 'error', listOptions.topicUid), err);
+    });
   });
 
   resultCloudTopics.on('update', function(resultToUpdate) {

--- a/lib/cloud/server-spec.js
+++ b/lib/cloud/server-spec.js
@@ -62,9 +62,9 @@ describe('Result Sync', function() {
     resultServer(mediator, app, mockMbaasApi);
 
     //Mock of the data topic subscriber in the storage module
-    mediator.subscribe(CLOUD_DATA_TOPICS.list, function() {
+    mediator.subscribe(CLOUD_DATA_TOPICS.list, function(filter) {
       //Publish to done list data topic to fake getting the list of results by storage module
-      mediator.publish(DONE + CLOUD_DATA_TOPICS.list, mockResultArray);
+      mediator.publish(DONE + CLOUD_DATA_TOPICS.list + ":" + filter.topicUid, mockResultArray);
     });
 
     return mediator.request(CLOUD_TOPICS.list).then(function(listResult) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-result",
-  "version": "0.2.4",
+  "version": "0.2.3",
   "description": "A result module for WFM, for working with the results of pushing a workorder through a workflow",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-result",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "A result module for WFM, for working with the results of pushing a workorder through a workflow",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Change

When working offline, the result will not get an `id` field until the updates are pushed to the server when coming back online.

The raincatcher-sync framework assigns a `_localuid` field to the object to identify the object in the local cache.

Therefore, a result object does not require a `id` field as it is created on the mobile app.